### PR TITLE
Added a new "stream" for opening trailer on youtube - on WebOS the original "stream" was not working

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -30,7 +30,7 @@ const config = {
     userAgent: process.env.USER_AGENT || 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36', // Update UA periodically
     addon: {
         id: 'community.ratings.aggregator',
-        version: '1.5.1', // Incremented version
+        version: '1.6.0', // Incremented version
         name: '🎯 Ratings Aggregator',
         description: 'Aggregated ratings from IMDb, TMDb, Metacritic, Common Sense, CringeMDB and more.',
         catalogs: [],

--- a/src/handlers/streamHandler.js
+++ b/src/handlers/streamHandler.js
@@ -60,7 +60,7 @@ async function streamHandler({ type, id }) {
 
         // Add standard ratings (IMDb, TMDb, Metacritic)
         ratings
-            .filter(r => ['IMDb', 'TMDb', 'MC', 'MC Users','RT' ,'RT Users'].includes(r.source))
+            .filter(r => ['IMDb', 'TMDb', 'MC', 'MC Users', 'RT', 'RT Users'].includes(r.source))
             .sort((a, b) => { // Sort for consistent order
                 const order = ['IMDb', 'TMDb', 'MC', 'MC Users', 'RT', 'RT Users'];
                 return order.indexOf(a.source) - order.indexOf(b.source);
@@ -88,6 +88,7 @@ async function streamHandler({ type, id }) {
         const stream = {
             name: "📊 Ratings Aggregator ", // Main title for the stream item
             description: formattedLines.join('\n'),
+            url: `${config.sources.imdbBaseUrl}/title/${id.split(':')[0]}/`, // FIX for WebOS - Dummy URL, won't be used
             // Use IMDb URL as a fallback/reference if no specific rating URL is best
             externalUrl: `${config.sources.imdbBaseUrl}/title/${id.split(':')[0]}/`,
             behaviorHints: {

--- a/src/handlers/streamHandler.js
+++ b/src/handlers/streamHandler.js
@@ -1,6 +1,7 @@
 const ratingService = require('../services/ratingService');
 const logger = require('../utils/logger');
 const config = require('../config');
+const { getTmdbTrailer } = require('../utils/tmdbService');
 
 // Helper function to get emoji for each rating source for display
 function getEmojiForSource(source) {
@@ -30,12 +31,12 @@ async function streamHandler({ type, id }) {
     }
 
     try {
+        streams = [];
         const ratings = await ratingService.getRatings(type, id);
 
         if (!ratings || ratings.length === 0) {
             logger.info(`No ratings found by service for: ${id}`);
             // Return an empty stream or a specific "No Ratings Found" stream
-            return Promise.resolve({ streams: [] });
             /*
             return Promise.resolve({ streams: [{
                  name: "📊 Ratings",
@@ -47,59 +48,82 @@ async function streamHandler({ type, id }) {
             */
         }
 
-        // Format ratings for display in the stream description
-        const formattedLines = [
-            "───────────────", // Separator
-        ];
+        else {
+            // Format ratings for display in the stream description
+            const formattedLines = [
+                "───────────────", // Separator
+            ];
 
-        // Prioritize Common Sense Media Age Rating
-        const commonSense = ratings.find(r => r.source === 'Common Sense');
-        if (commonSense) {
-            formattedLines.push(`${getEmojiForSource(commonSense.source)} ${commonSense.value}`);
+            // Prioritize Common Sense Media Age Rating
+            const commonSense = ratings.find(r => r.source === 'Common Sense');
+            if (commonSense) {
+                formattedLines.push(`${getEmojiForSource(commonSense.source)} ${commonSense.value}`);
+            }
+
+            // Add standard ratings (IMDb, TMDb, Metacritic)
+            ratings
+                .filter(r => ['IMDb', 'TMDb', 'MC', 'MC Users', 'RT', 'RT Users'].includes(r.source))
+                .sort((a, b) => { // Sort for consistent order
+                    const order = ['IMDb', 'TMDb', 'MC', 'MC Users', 'RT', 'RT Users'];
+                    return order.indexOf(a.source) - order.indexOf(b.source);
+                })
+                .forEach(rating => {
+                    const emoji = getEmojiForSource(rating.source);
+                    // Pad source name for alignment (adjust padding as needed)
+                    formattedLines.push(
+                        `${emoji} ${rating.source.padEnd(9)}: ${rating.value}`
+                    );
+                });
+
+            // Add CringeMDB Warnings/Certification at the end
+            const cringeMdb = ratings.find(r => r.source === 'CringeMDB' || r.source === 'Certification');
+            if (cringeMdb) {
+                // Split multi-line value from CringeMDB
+                cringeMdb.value.split('\n').forEach(line => {
+                    if (line.trim()) formattedLines.push(`${line.trim()}`);
+                });
+            }
+
+            formattedLines.push("───────────────"); // Final Separator
+
+            // Create the stream object for Stremio
+            const imdbPageStream = {
+                name: "📊 Click for IMDB Page ", // Main title for the stream item
+                description: formattedLines.join('\n'),
+                // Use IMDb URL as a fallback/reference if no specific rating URL is best
+                externalUrl: `${config.sources.imdbBaseUrl}/title/${id.split(':')[0]}/`,
+                behaviorHints: {
+                    notWebReady: true, // Important: Indicates this isn't a playable video stream
+                    bingeGroup: `ratings-${id}` // Group rating streams together for an item
+                },
+                type: "other", // Custom stream type
+            };
+
+            streams.push(imdbPageStream);
+
+            const ytId = await getTmdbTrailer(type, id);
+
+            if (!ytId) {
+                logger.info(`No trailers found by service for: ${id}`);
+            }
+
+            else {
+                // Create the stream object for Stremio
+                const trailerStream = {
+                    name: "🎞️ Click for Trailer ", // Main title for the stream item
+                    description: formattedLines.join('\n'),
+                    ytId: ytId,
+                    behaviorHints: {
+                        bingeGroup: `ratings-${id}` // Group rating streams together for an item
+                    },
+                };
+
+                streams.push(trailerStream);
+            }
         }
 
-        // Add standard ratings (IMDb, TMDb, Metacritic)
-        ratings
-            .filter(r => ['IMDb', 'TMDb', 'MC', 'MC Users', 'RT', 'RT Users'].includes(r.source))
-            .sort((a, b) => { // Sort for consistent order
-                const order = ['IMDb', 'TMDb', 'MC', 'MC Users', 'RT', 'RT Users'];
-                return order.indexOf(a.source) - order.indexOf(b.source);
-            })
-            .forEach(rating => {
-                const emoji = getEmojiForSource(rating.source);
-                // Pad source name for alignment (adjust padding as needed)
-                formattedLines.push(
-                    `${emoji} ${rating.source.padEnd(9)}: ${rating.value}`
-                );
-            });
-
-        // Add CringeMDB Warnings/Certification at the end
-        const cringeMdb = ratings.find(r => r.source === 'CringeMDB' || r.source === 'Certification');
-        if (cringeMdb) {
-            // Split multi-line value from CringeMDB
-            cringeMdb.value.split('\n').forEach(line => {
-                if (line.trim()) formattedLines.push(`${line.trim()}`);
-            });
-        }
-
-        formattedLines.push("───────────────"); // Final Separator
-
-        // Create the stream object for Stremio
-        const stream = {
-            name: "📊 Ratings Aggregator ", // Main title for the stream item
-            description: formattedLines.join('\n'),
-            url: `${config.sources.imdbBaseUrl}/title/${id.split(':')[0]}/`, // FIX for WebOS - Dummy URL, won't be used
-            // Use IMDb URL as a fallback/reference if no specific rating URL is best
-            externalUrl: `${config.sources.imdbBaseUrl}/title/${id.split(':')[0]}/`,
-            behaviorHints: {
-                notWebReady: true, // Important: Indicates this isn't a playable video stream
-                bingeGroup: `ratings-${id}` // Group rating streams together for an item
-            },
-            type: "other", // Custom stream type
-        };
-
-        logger.info(`Returning 1 rating stream for ${id}`);
-        return Promise.resolve({ streams: [stream] });
+        logger.info(`Returning ${streams.length} rating streams for ${id}`);
+        return Promise.resolve({ streams: streams });
 
     } catch (error) {
         // Catch errors from the ratingService call itself

--- a/src/server.js
+++ b/src/server.js
@@ -52,7 +52,7 @@ async function startServer() {
 
     // Start HTTP server
     const port = config.port;
-    app.listen(port, () => {
+    app.listen(port, '0.0.0.0', () => {
         const url = `http://localhost:${port}`;
         logger.info(`Addon server listening on ${url}`);
         logger.info(`Configure/install via ${url}/configure`);


### PR DESCRIPTION
LG TVs Rating Aggregator was not working. The reason is that WebOS is expecting a "ytId" or "url" property inside stream. However, after I added a dummy "url" property, when clicking the Rating Aggregator "stream", Stremio would try to play as a video what is inside the "url" property. In the end I fixed this issue by adding the "ytId" property to a new "stream" so that platforms that do not support the "Open on IMDB" would also be able to see the ratings and open them as trailers.

I also created a sort functionality of trailers, so that the highest quality video of type 'Trailer' is picked first.

Thank you for your contribution to Stremio addons!

Edit: this is my first PR in JS so feel free to correct anything :D